### PR TITLE
Update Maven configuration for EE BOM resolution

### DIFF
--- a/.github/workflows/run-munits.yaml
+++ b/.github/workflows/run-munits.yaml
@@ -57,6 +57,12 @@ jobs:
                 <username>~~~Client~~~</username>
                 <password>${ANYPOINT_CLIENT_ID}~?~${ANYPOINT_CLIENT_SECRET}</password>
               </server>
+              <!-- Required for MUnit EE runtime BOM resolution -->
+              <server>
+                <id>mulesoft-enterprise-repository</id>
+                <username>~~~Client~~~</username>
+                <password>${ANYPOINT_CLIENT_ID}~?~${ANYPOINT_CLIENT_SECRET}</password>
+              </server>
             </servers>
           </settings>
           EOSETTINGS

--- a/ridexpress-experience-api/pom.xml
+++ b/ridexpress-experience-api/pom.xml
@@ -80,6 +80,19 @@
             <url>https://repository.mulesoft.org/releases/</url>
             <layout>default</layout>
         </repository>
+        <!-- Required for MUnit EE runtime BOM (com.mulesoft.mule.distributions) -->
+        <repository>
+            <id>mulesoft-enterprise-repository</id>
+            <name>MuleSoft Enterprise Repository</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases-ee/</url>
+            <layout>default</layout>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
@@ -87,6 +100,16 @@
             <name>mulesoft release repository</name>
             <layout>default</layout>
             <url>https://repository.mulesoft.org/releases/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+        <!-- Required for MUnit EE runtime BOM (com.mulesoft.mule.distributions) -->
+        <pluginRepository>
+            <id>mulesoft-enterprise-repository</id>
+            <name>MuleSoft Enterprise Repository</name>
+            <url>https://repository.mulesoft.org/nexus/content/repositories/releases-ee/</url>
+            <layout>default</layout>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
This pull request adds configuration for the MuleSoft Enterprise Repository to support resolving the MUnit EE runtime BOM (Bill of Materials). The changes ensure that both Maven and the CI workflow have access to the necessary enterprise dependencies and plugins for MUnit EE.

Repository and plugin repository configuration:

* Added the `mulesoft-enterprise-repository` to the `<repositories>` section in `ridexpress-experience-api/pom.xml` to enable resolution of enterprise artifacts required by MUnit EE.
* Added the `mulesoft-enterprise-repository` to the `<pluginRepositories>` section in `ridexpress-experience-api/pom.xml` for plugin resolution.

CI/CD workflow configuration:

* Updated `.github/workflows/run-munits.yaml` to include credentials for the `mulesoft-enterprise-repository` in the Maven settings, allowing the workflow to authenticate and download enterprise dependencies.